### PR TITLE
run 3 times a day

### DIFF
--- a/openshift/templates/perimeter_cronjob.yaml
+++ b/openshift/templates/perimeter_cronjob.yaml
@@ -35,7 +35,7 @@ parameters:
   - name: JOB_NAME
     value: fire-perimeter
   - name: SCHEDULE
-    value: "30 12 * * *"
+    value: "30 0,8,16 * * *"
     required: true
   - name: POSTGRES_WRITE_HOST
     required: true


### PR DESCRIPTION
Run cronjob more frequently - 3 times a day.

There's a significant amount of lag from images being acquired by satellite to being updated in google earth engine.